### PR TITLE
Update CopernicaRequest.php

### DIFF
--- a/src/CopernicaRequest.php
+++ b/src/CopernicaRequest.php
@@ -71,6 +71,8 @@ class CopernicaRequest
 
         // get request body
         $this->body = file_get_contents('php://input');
+ 	    // if not set in php://input, try $_POST
+ 	    if (empty($this->body) && !empty($_POST)) $this->body = http_build_query($_POST);
 
         // check if digest matches
         if (!$digest->matches($this->body)) throw new \Exception('Digest header does not match body data');
@@ -88,10 +90,6 @@ class CopernicaRequest
             throw new \Exception("Invalid signature: the Host header is not included in the signature");
         if (!$verifier->contains('Date'))
             throw new \Exception("Invalid signature: the Date header is not included in the signature");
-        if (!$verifier->contains("Content-length"))
-            throw new \Exception("Invalid signature: the Content-length header is not included in the signature");
-        if (!$verifier->contains("Content-type"))
-            throw new \Exception("Invalid signature: the Content-type header is not included in the signature");
         if (!$verifier->contains("Digest"))
             throw new \Exception("Invalid signature: the Digest header is not included in the signature");
         if (!$verifier->contains("x-nonce"))


### PR DESCRIPTION
Posting arrays will change content-length and content-type and therefor invalidating the Digest. Posting arrays will change the content-type to multipart/form-data and make the php://input unavailable When Posting arrays the data will be in $_POST